### PR TITLE
Fix jest test for default prompt

### DIFF
--- a/__tests__/bot.test.js
+++ b/__tests__/bot.test.js
@@ -30,7 +30,9 @@ describe('Discord OpenAI Bot', () => {
     sendToOpenAI.mockResolvedValue('response from openai');
     const message = { author: { bot: false }, content: 'hello', reply: jest.fn() };
     await client.listeners['messageCreate'](message);
-    expect(sendToOpenAI).toHaveBeenCalledWith(process.env.SYSTEM_PROMPT, 'hello');
+    const expectedPrompt = process.env.SYSTEM_PROMPT ||
+      'You are a helpful assistant. Only answer with facts.';
+    expect(sendToOpenAI).toHaveBeenCalledWith(expectedPrompt, 'hello');
     expect(message.reply).toHaveBeenCalledWith('response from openai');
   });
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node index.js",
-    "test": "jest --experimental-vm-modules"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- enable Node's ESM support when running tests
- update the test to expect the default system prompt value

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b8a5e9b14832e89cdf667d2ae9d3c